### PR TITLE
Load scripts without modules so gacha works

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
     </section>
   </main>
 
-<script type="module" src="js/game.js"></script>
+<script src="js/save.js"></script>
+<script src="js/game.js"></script>
 </body>
 </html>

--- a/js/game.js
+++ b/js/game.js
@@ -1,5 +1,5 @@
 
-import { loadState, saveState } from './save.js';
+// Save/load helpers are now loaded from save.js (classic script)
 
 /**
  * ATOM GACHA — Prototype Idle (v4)

--- a/js/save.js
+++ b/js/save.js
@@ -1,4 +1,4 @@
-export function emptyState(){
+function emptyState(){
   return {
     inventory: {},
     pulls: 0,
@@ -15,7 +15,7 @@ function computePoints(state){
   return Object.values(state.inventory).reduce((a,b)=>a + (b?.count||0), 0);
 }
 
-export function loadState(){
+function loadState(){
   if (typeof localStorage === 'undefined') {
     console.warn('Persistence disabled: no localStorage');
     return emptyState();
@@ -33,7 +33,7 @@ export function loadState(){
   }
 }
 
-export function saveState(state){
+function saveState(state){
   if (typeof localStorage === 'undefined') {
     console.warn('Persistence disabled: no localStorage');
     return;
@@ -49,3 +49,7 @@ export function saveState(state){
     // ignore quota errors
   }
 }
+
+// Expose helpers globally for game.js
+window.loadState = loadState;
+window.saveState = saveState;


### PR DESCRIPTION
## Summary
- Load save.js before game.js and remove module imports
- Expose save/load helpers globally

## Testing
- `node --check js/save.js`
- `node --check js/game.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd40f59b64832e87f0565c11d60e14