### PR TITLE
Implement double rarity rolls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -45,12 +45,6 @@ input { background: rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.
 .t-epique{ color:#a855f7; }
 .t-legendaire{ color:#f59e0b; }
 
-.t-mult-x1{ color:#e5e7eb; }
-.t-mult-x2{ color:#3b82f6; }
-.t-mult-x5{ color:#3b82f6; }
-.t-mult-x10{ color:#a855f7; }
-.t-mult-x25{ color:#f59e0b; }
-
 
 /* Tableau périodique */
 .periodic-table{ display:grid; grid-template-columns:repeat(18, 40px); grid-auto-rows:40px; gap:4px; }


### PR DESCRIPTION
## Summary
- Draw base and multiplier rarities separately and multiply their amounts for final reward
- Show both rarities in pull result logs
- Remove unused multiplier color classes

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5b994964832eb6588d942666fd00