### PR TITLE
Add lanthanide and actinide levels

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -67,5 +67,7 @@ input { background: rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.
 .pt-cell.lvl5{ background:rgba(231,111,81,0.6); }
 .pt-cell.lvl6{ background:rgba(157,78,221,0.6); }
 .pt-cell.lvl7{ background:rgba(186,92,186,0.6); }
+.pt-cell.lvl8{ background:rgba(206,147,216,0.6); }
+.pt-cell.lvl9{ background:rgba(233,128,252,0.6); }
 
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
           <h2 data-i18n="pullsHeader">Tirages</h2>
           <div class="row" style="margin-bottom:10px">
             <label for="levelSlider" data-i18n="levelLabel">Niveau :</label>
-            <input type="range" id="levelSlider" min="1" max="7" value="1" />
+            <input type="range" id="levelSlider" min="1" max="9" value="1" />
             <span id="levelValue">1</span>
           </div>
           <div class="row pull-buttons" style="margin-bottom:10px">


### PR DESCRIPTION
## Summary
- Separate lanthanides and actinides into new levels 8 and 9
- Extend draw pools, shop items, and slider to handle up to 9 levels
- Style periodic table cells for the new levels

## Testing
- `node --check js/game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6755747c832e9335f9b32d520c0f