### PR TITLE
Add re-purchasable draw multiplier item

### DIFF
--- a/js/save.js
+++ b/js/save.js
@@ -9,11 +9,13 @@ function emptyState(){
     credits: { gems: 0, energy: 0 },
     language: 'fr',
     levelsUnlocked: 1,
+    pullMult: 0,
   };
 }
 
 function computePoints(state){
-  return Object.values(state.inventory).reduce((a,b)=>a + (b?.count||0), 0);
+  const values = window.ATOM_VALUE_MAP || {};
+  return Object.entries(state.inventory).reduce((a,[id,b])=>a + (b?.count||0)*(values[id]||1), 0);
 }
 
 function loadState(){
@@ -29,6 +31,7 @@ function loadState(){
     if(!st.credits) st.credits = { gems:0, energy:0 };
     if(!st.language) st.language = 'fr';
     if(!st.levelsUnlocked) st.levelsUnlocked = 1;
+    if(typeof st.pullMult !== 'number') st.pullMult = 0;
     return st;
   } catch(e){
     return emptyState();


### PR DESCRIPTION
## Summary
- add draw multiplier property to save state
- apply purchased multipliers to pulls and add x2 multiplier shop item
- apply shop multiplier after base pull result and show multiplier in roll logs
- revalue atom groups and apply per-level x10 pull costs

## Testing
- `node --check js/game.js`
- `node --check js/save.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6b305444832e8b556f5f94983701