### PR TITLE
Round display values to nearest integer

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -116,6 +116,10 @@ function ensureInv(state, atomId){ if(!state.inventory[atomId]) state.inventory[
 function computeOwned(state){ return Object.values(state.inventory).reduce((a,b)=>a + (b?.count||0), 0); }
 function computePoints(state){ return Object.entries(state.inventory).reduce((a,[id,b])=>a + (b?.count||0)*(ATOM_VALUE_MAP[id]||1), 0); }
 function getPullMultiplier(st){ return Math.pow(2, st.pullMult || 0); }
+function roundDisplay(value){
+  const decimal = value - Math.floor(value);
+  return decimal < 0.5 ? Math.floor(value) : Math.ceil(value);
+}
 
 function spendAtoms(st, amount){
   if(computePoints(st) < amount) return false;
@@ -279,11 +283,11 @@ langSelect.addEventListener('change', ()=>{
 
 function renderTop(){
   const st = state;
-  const total = computePoints(st);
+  const total = roundDisplay(computePoints(st));
   pointsEl.textContent = total;
   pityEl.textContent = st.pity;
   pullsEl.textContent = st.pulls;
-  ownedEl.textContent = computeOwned(st);
+  ownedEl.textContent = roundDisplay(computeOwned(st));
   lastSeenEl.textContent = new Date(st.lastSeen).toLocaleString();
   refreshLevelSlider();
 }
@@ -330,7 +334,7 @@ function renderCollection(){
       sym.className = 'sym';
       sym.textContent = id;
       cell.append(num, sym);
-      cell.title = `${a.name} (L${a.level}) — Possédés: ${inv.count} | Mult total: x${inv.totalMult.toFixed(2)}`;
+      cell.title = `${a.name} (L${a.level}) — Possédés: ${roundDisplay(inv.count)} | Mult total: x${roundDisplay(inv.totalMult)}`;
       collectionEl.append(cell);
     });
   });


### PR DESCRIPTION
## Summary
- Add rounding helper that drops decimals and rounds 0.5 up
- Round totals, owned counts, and collection multipliers for cleaner display

## Testing
- `node --check js/game.js`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Atom/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68bd81f0ec5c832e8f347dbefdb6055f