### PR TITLE
feat: responsive main page redesign

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6,6 +6,11 @@ header { padding: 12px 16px; display:flex; align-items: center; justify-content:
 .title { display:flex; align-items:center; gap:12px; font-weight:700; letter-spacing:0.3px; }
 .dot { width:12px; height:12px; border-radius:999px; background: var(--accent); box-shadow: 0 0 18px var(--accent); }
 .wrap { max-width: 1000px; margin: 0 auto; padding: 0 16px 64px; }
+.topbar{display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap;}
+.topbar .menus, .topbar .accounts{display:flex;align-items:center;gap:12px;flex-wrap:wrap;}
+.group-selector{display:grid;grid-template-columns:repeat(9,1fr);gap:4px;margin:16px 0;}
+.group-selector button{width:100%;padding:8px 0;}
+.group-selector button.active{background:var(--text);color:var(--bg);}
 .panels { display:grid; grid-template-columns: 1fr; gap:16px; }
 .panel { background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 16px; box-shadow: 0 6px 24px rgba(0,0,0,0.25); }
 .row { display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
@@ -30,12 +35,15 @@ input { background: rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.
 .atom { width:44px; height:44px; border-radius: 10px; background: rgba(255,255,255,0.06); display:flex; align-items:center; justify-content:center; font-weight:800; font-size: 1rem; }
 .atom img{width:100%;height:100%;object-fit:contain;}
 .log { height: 260px; overflow:auto; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; background: rgba(0,0,0,0.25); border-radius: 12px; padding: 10px; border: 1px dashed rgba(255,255,255,0.15) }
-.pill { padding:6px 10px; border:1px solid rgba(255,255,255,0.15); border-radius: 999px; }
 .footer { margin-top:12px; font-size: 0.85rem; }
 
 /* Pages */
 .page { display:none; }
 .page.active { display:block; }
+
+@media (orientation: landscape){
+  .panels{grid-template-columns:1fr 1fr;}
+}
 
 
 /* Couleurs de texte par rareté */

--- a/index.html
+++ b/index.html
@@ -10,16 +10,19 @@
 
   <header class="wrap">
     <div class="title"><div class="dot"></div> <span data-i18n="title">Atom Gacha — Prototype</span></div>
-    <div class="row">
-      <div id="pointsStat" class="stat"><span data-i18n="pointsStat">◆ Points (total atomes):</span> <span id="points">0</span></div>
-      <div class="stat"><span data-i18n="idleStat">⏱️ Idle: 1 tirage/min</span></div>
-
-      <button id="btnCollection" class="secondary" data-i18n="btnCollection">Collection</button>
-      <button id="btnShop" class="secondary" data-i18n="btnShop">Magasin</button>
-      <select id="langSelect">
-        <option value="fr">FR</option>
-        <option value="en">EN</option>
-      </select>
+    <div class="topbar">
+      <div class="menus">
+        <button id="btnCollection" class="secondary" data-i18n="btnCollection">Collection</button>
+        <button id="btnShop" class="secondary" data-i18n="btnShop">Magasin</button>
+        <select id="langSelect">
+          <option value="fr">FR</option>
+          <option value="en">EN</option>
+        </select>
+      </div>
+      <div class="accounts">
+        <div id="pointsStat" class="stat"><span data-i18n="pointsStat">◆ Points (total atomes):</span> <span id="points">0</span></div>
+        <div class="stat"><span data-i18n="idleStat">⏱️ Idle: 1 tirage/min</span></div>
+      </div>
     </div>
   </header>
 
@@ -27,38 +30,34 @@
 
     <!-- Page Principale -->
     <section id="page-main" class="page active">
-      <div class="panels">
-        <section class="panel">
-          <h2 data-i18n="pullsHeader">Tirages</h2>
-          <div class="row" style="margin-bottom:10px">
-            <label for="levelSlider" data-i18n="levelLabel">Niveau :</label>
-            <input type="range" id="levelSlider" min="1" max="9" value="1" />
-            <span id="levelValue">1</span>
-          </div>
-          <div class="row pull-buttons" style="margin-bottom:10px">
-            <button id="pull1" data-i18n="pull1">×1</button>
-            <button id="pull10" data-i18n="pull10">×10</button>
-            <span class="muted" data-i18n="pullHint">Raretés : 1, 2, 5, 10, 25.</span>
-          </div>
-          <div id="lastResult" class="panel" style="padding:12px; margin-bottom:12px">
-            <div class="muted" data-i18n="lastResultTitle">Dernier résultat</div>
-            <div id="resultText" style="font-weight:800; margin-top:4px">—</div>
-          </div>
-          <div class="log" id="log"></div>
-          <div class="footer muted" data-i18n="footer">Idle: 1 tirage gratuit par minute (y compris hors‑ligne, sans animation, sauf gros tirages).</div>
-        </section>
-
-        <section class="panel">
-          <h2 data-i18n="statsHeader">Stats</h2>
-          <div class="row">
-            <div class="pill"><span data-i18n="owned">Éléments possédés :</span> <span id="owned">0</span></div>
-            <div class="pill"><span data-i18n="pity">Pitié:</span> <span id="pity">0</span>/50</div>
-            <div class="pill"><span data-i18n="pulls">Tirages totaux:</span> <span id="pulls">0</span></div>
-            <div class="pill"><span data-i18n="lastSave">Dernière sauvegarde :</span> <span id="lastSeen">—</span></div>
-          </div>
-        </section>
+      <div id="levelSelector" class="group-selector">
+        <button class="level-btn active" data-level="1">1</button>
+        <button class="level-btn" data-level="2">2</button>
+        <button class="level-btn" data-level="3">3</button>
+        <button class="level-btn" data-level="4">4</button>
+        <button class="level-btn" data-level="5">5</button>
+        <button class="level-btn" data-level="6">6</button>
+        <button class="level-btn" data-level="7">7</button>
+        <button class="level-btn" data-level="8">8</button>
+        <button class="level-btn" data-level="9">9</button>
       </div>
-    </section>
+        <div class="panels">
+          <section class="panel">
+            <h2 data-i18n="pullsHeader">Tirages</h2>
+            <div class="row pull-buttons" style="margin-bottom:10px">
+              <button id="pull1" data-i18n="pull1">×1</button>
+              <button id="pull10" data-i18n="pull10">×10</button>
+              <span class="muted" data-i18n="pullHint">Raretés : 1, 2, 5, 10, 25.</span>
+            </div>
+            <div id="lastResult" class="panel" style="padding:12px; margin-bottom:12px">
+              <div class="muted" data-i18n="lastResultTitle">Dernier résultat</div>
+              <div id="resultText" style="font-weight:800; margin-top:4px">—</div>
+            </div>
+            <div class="log" id="log"></div>
+            <div class="footer muted" data-i18n="footer">Idle: 1 tirage gratuit par minute (y compris hors‑ligne, sans animation, sauf gros tirages).</div>
+          </section>
+        </div>
+      </section>
 
     <!-- Page Collection -->
     <section id="page-collection" class="page">

--- a/js/save.js
+++ b/js/save.js
@@ -1,8 +1,6 @@
 function emptyState(){
   return {
     inventory: {},
-    pulls: 0,
-    pity: 0,
     lastTick: Date.now(),
     lastSeen: Date.now(),
     idleAccum: 0,

--- a/save.sav
+++ b/save.sav
@@ -1,1 +1,1 @@
-{"inventory":{},"pulls":0,"pity":0,"lastTick":0,"lastSeen":0,"idleAccum":0,"credits":{"gems":0,"energy":0},"atomCount":0,"savedAt":0}
+{"inventory":{},"lastTick":0,"lastSeen":0,"idleAccum":0,"credits":{"gems":0,"energy":0},"atomCount":0,"savedAt":0}


### PR DESCRIPTION
## Summary
- overhaul header layout with separate menu and account groups
- add wide clickable group selector for levels 1-9
- make panels responsive to screen orientation and remove last save line
- drop stats panel and pity system

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/game.js`
- `node --check js/save.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd90f666a8832eaa5628f13502f460