### PR TITLE
Make results box span full width responsively

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -11,7 +11,7 @@ header { padding: 12px 16px; display:flex; align-items: center; justify-content:
 .group-selector{display:grid;grid-template-columns:repeat(9,1fr);gap:4px;margin:16px 0;}
 .group-selector button{width:100%;padding:8px 0;}
 .group-selector button.active{background:var(--text);color:var(--bg);}
-.panels { display:grid; grid-template-columns: 1fr; gap:16px; }
+.panels { display:grid; gap:16px; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
 .panel { background: linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; padding: 16px; box-shadow: 0 6px 24px rgba(0,0,0,0.25); }
 .row { display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
 .stat { display:flex; align-items:center; gap:8px; padding:8px 12px; border-radius: 999px; background: rgba(124,92,255,0.12); border:1px solid rgba(124,92,255,0.35); }
@@ -34,16 +34,13 @@ input { background: rgba(255,255,255,0.06); border:1px solid rgba(255,255,255,0.
 .rar-Légendaire { background: rgba(245,158,11,0.25); border-color: rgba(245,158,11,0.5) }
 .atom { width:44px; height:44px; border-radius: 10px; background: rgba(255,255,255,0.06); display:flex; align-items:center; justify-content:center; font-weight:800; font-size: 1rem; }
 .atom img{width:100%;height:100%;object-fit:contain;}
-.log { height: 260px; overflow:auto; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; background: rgba(0,0,0,0.25); border-radius: 12px; padding: 10px; border: 1px dashed rgba(255,255,255,0.15) }
+.log { width:100%; height: 260px; overflow:auto; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; background: rgba(0,0,0,0.25); border-radius: 12px; padding: 10px; border: 1px dashed rgba(255,255,255,0.15) }
 .footer { margin-top:12px; font-size: 0.85rem; }
 
 /* Pages */
 .page { display:none; }
 .page.active { display:block; }
 
-@media (orientation: landscape){
-  .panels{grid-template-columns:1fr 1fr;}
-}
 
 
 /* Couleurs de texte par rareté */


### PR DESCRIPTION
## Summary
- allow result panel to use full screen width via responsive grid
- ensure results log grows to 100% width

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe01c875c832eb0a0cc70db7bf3d8